### PR TITLE
Add sub-communities as feature

### DIFF
--- a/listOfFeaturesOfGreatOSBCs.md
+++ b/listOfFeaturesOfGreatOSBCs.md
@@ -37,3 +37,5 @@
 ## Well designed strategy to increase its visibility to the community (use of social media, conferences etc.)
 
 ## Offer different levels of contributions (e.g. Code contributions, documentation enhancements, User support)
+
+## If possible split the project in subprojects to grow small sub-communities inside of yours


### PR DESCRIPTION
If a community is too large you will have sooner or later small sub communities. This can be supported from the beginning. Splitting the projects into smaller repositories will grow automatically small sub-communities. For example plugins can be hosted in it's own repository with different, more relaxed committing rules than the core application.
